### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/arielsrv/traffic-replayer/security/code-scanning/3](https://github.com/arielsrv/traffic-replayer/security/code-scanning/3)

To fix this problem, you should add an explicit `permissions` block to the workflow YAML file minimizing the permissions granted to the GITHUB_TOKEN. The simplest and safest change is to add `permissions: contents: read` at the root of the workflow or inside the `build` job. Since the workflow only involves code checkout and building, it does not require write access. The recommended place is at the root, right after the workflow `name:` and before `on:`, to cover all jobs by default (since there is only one job). This fix requires no additional methods, imports, or dependencies, as it is a configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to explicitly grant read-only access to repository contents.
  * Declares a clear permission scope for automation tasks.
  * Applies only to pipeline configuration; no changes to features, UI, or performance.
  * Build, test, and deployment behavior remain unchanged.
  * Improves configuration clarity and aligns with least-privilege practices without affecting end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->